### PR TITLE
Allow any type of resource to be uploaded

### DIFF
--- a/lib/active_storage/service/cloudinary_service.rb
+++ b/lib/active_storage/service/cloudinary_service.rb
@@ -17,7 +17,7 @@ module ActiveStorage
 
     def upload(key, io, checksum: nil)
       instrument :upload, key: key, checksum: checksum do
-        Cloudinary::Uploader.upload(io, public_id: key)
+        Cloudinary::Uploader.upload(io, public_id: key, resource_type: "auto")
       end
     end
 


### PR DESCRIPTION
If not uploading an image, you will get this error: Invalid image file

This allows any type of file to be uploaded.