### PR TITLE
Fix direct uploads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     activestorage-cloudinary-service (0.2.0)
+      activesupport (~> 5.2)
 
 GEM
   remote: https://rubygems.org/
@@ -108,6 +109,7 @@ PLATFORMS
 DEPENDENCIES
   activestorage (~> 5.2.0)
   activestorage-cloudinary-service!
+  activesupport (~> 5.2)
   bundler (~> 1.16)
   cloudinary (~> 1.8.2)
   pry (~> 0.11.3)

--- a/activestorage-cloudinary-service.gemspec
+++ b/activestorage-cloudinary-service.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'activesupport', '~> 5.2'
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'pry', '~> 0.11.3'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,8 +15,10 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'test_dummies'
+require 'active_support/testing/time_helpers'
 
 RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/test_dummies.rb
+++ b/spec/test_dummies.rb
@@ -6,46 +6,4 @@ module ActiveStorage
   end
 end
 
-module DummyCloudinary
-  class << self
-    %i[cloud_name api_key api_secret cname upload_preset].each do |mtd|
-      attr_accessor mtd
-    end
-
-    def config(options)
-      options.each { |k, v| send("#{k}=", v) }
-    end
-  end
-
-  class Uploader
-    def self.upload(_file, _options = {}); end
-
-    def self.destroy(_key); end
-  end
-
-  class Api
-    def self.resources(_options); end
-
-    def self.resources_by_ids(_public_id); end
-
-    def self.delete_resources_by_prefix(_prefix); end
-  end
-
-  class Downloader
-    def self.download(_key); end
-  end
-
-  class Utils
-    def self.private_download_url(_public_id, _format, _options); end
-
-    def self.resource_type_for_format(ext)
-      %w[png pdf].include?(ext) ? 'image' : 'raw'
-    end
-
-    def self.cloudinary_url(key)
-      "https://#{key}"
-    end
-  end
-end
-
 require 'active_storage/service/cloudinary_service'


### PR DESCRIPTION
While direct uploads to Cloudinary do not work with Rails default frontend library, we were able to use it with the [uppy](https://github.com/transloadit/uppy) as an uploader - but as Cloudinary's `upload` endpoint is a bit more limited than `download`,  it required us to do some small changes to this adapter.
This PR fixes https://github.com/0sc/activestorage-cloudinary-service/issues/2 for apps with the custom frontend.
