### PR TITLE
Fix `ArgumentError` when uploading to Cloudinary

### DIFF
--- a/lib/active_storage/service/cloudinary_service.rb
+++ b/lib/active_storage/service/cloudinary_service.rb
@@ -19,7 +19,7 @@ module ActiveStorage
       # Cloudinary.config_from_url(url)
     end
 
-    def upload(key, io, checksum: nil)
+    def upload(key, io, checksum: nil, **)
       instrument :upload, key: key, checksum: checksum do
         Cloudinary::Uploader.upload(io, public_id: key, resource_type: 'auto')
       end


### PR DESCRIPTION
See https://github.com/rails/rails/pull/34550

Also Cloudinary Gem has been updated to [fix security issues with rest-client](https://github.com/cloudinary/cloudinary_gem/issues/322#issuecomment-438466389) but not yet released.

Add this to your Gemfile:

```
# Gemfile
gem "cloudinary", "1.10.1.pre.rc"
```